### PR TITLE
sd: Allow cart to work without SD card inserted

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ void setup() {
 
   if (!sd.begin(SdioConfig(FIFO_SDIO))) {
     Serial.println("Failed to detect sd card");
-    sd.initErrorHalt(&Serial);
+    sd.initErrorPrint(&Serial);
   } else {
     sdDetected = true;
   }


### PR DESCRIPTION
No reason to make the SD card required, replace Error Halt with Error Print.